### PR TITLE
Implement info/error dialog istead alert

### DIFF
--- a/imports/ui/infoErrDialog.jsx
+++ b/imports/ui/infoErrDialog.jsx
@@ -36,8 +36,9 @@ const SetInfoErrDialog = function (ele) {
 
     var dlgType = ele.state.dlgType ? ele.state.dlgType : DLG_TYPE_INFO;
     var dlgOpen = ele.state.dlgOpen ? ele.state.dlgOpen : false;
+    var titleColor = dlgType === DLG_TYPE_WARNING ? "red" : "green";
 
-    return <Dialog title={ dlgType === DLG_TYPE_WARNING ? 'WARNING' : 'INFO'}  open={dlgOpen} onRequestClose={ele.closeInfoErrDialog.bind(ele)} >
+    return <Dialog title={ dlgType === DLG_TYPE_WARNING ? 'WARNING' : 'INFOMATION'} titleStyle={{color: titleColor, fontWeight: 'bold' }}  open={dlgOpen} onRequestClose={ele.closeInfoErrDialog.bind(ele)} >
                {ele.state.dlgmsg ? ele.state.dlgmsg : ""}
            </Dialog>
 }

--- a/imports/ui/infoErrDialog.jsx
+++ b/imports/ui/infoErrDialog.jsx
@@ -5,39 +5,39 @@ import ReactDOM from 'react-dom';
 const DLG_TYPE_WARNING = 'warning';
 const DLG_TYPE_INFO = 'info';
 
-// This function MUST be called at contructor
-export var IniEleWithInfoErrDialog = function (ele)
-{
-  ele.state.dlgType = DLG_TYPE_INFO; // info, warning
-  ele.state.dlgOpen = false;
-  ele.state.msg = "";
+
+export var SetInfoErrDialogMethods = function (ele) {
+
+    ele.showErr = function (msg) {
+        ele.setState({
+            dlgType: DLG_TYPE_WARNING,
+            dlgOpen: true,
+            dlgmsg: msg
+        });
+    }
+
+    ele.showInfo = function (msg) {
+        ele.setState({
+            dlgType: DLG_TYPE_INFO,
+            dlgOpen: true,
+            dlgmsg: msg
+        });
+    }
+
+    ele.closeInfoErrDialog = function (){
+        ele.setState({
+            dlgOpen: false
+        });
+    }
+
 }
 
 export var SetInfoErrDialog = function (ele) {
 
-  ele.showErr = function (msg) {
-     ele.setState({
-      dlgType: DLG_TYPE_WARNING,
-      dlgOpen: true,
-      msg: msg
-    })   
-  }
+    var dlgType = ele.state.dlgType ? ele.state.dlgType : DLG_TYPE_INFO;
+    var dlgOpen = ele.state.dlgOpen ? ele.state.dlgOpen : false;
 
-  ele.showInfo = function (msg) {
-      ele.setState({
-      dlgType: DLG_TYPE_INFO,
-      dlgOpen: true,
-      msg: msg
-    })       
-  }
-
-  ele.closeInfoErrDialog = function (){
-    ele.setState({
-      dlgOpen: false
-    }) 
-  }
-  
-  return <Dialog title={ ele.state.dlgType == DLG_TYPE_WARNING ? 'WARNING' : 'INFO'}  open={ele.state.dlgOpen} onRequestClose={ele.closeInfoErrDialog.bind(ele)} >
-            {ele.state.msg}
-         </Dialog>
+    return <Dialog title={ dlgType === DLG_TYPE_WARNING ? 'WARNING' : 'INFO'}  open={dlgOpen} onRequestClose={ele.closeInfoErrDialog.bind(ele)} >
+               {ele.state.dlgmsg ? ele.state.dlgmsg : ""}
+           </Dialog>
 }

--- a/imports/ui/infoErrDialog.jsx
+++ b/imports/ui/infoErrDialog.jsx
@@ -1,0 +1,43 @@
+import React, {Component, PropTypes} from 'react';
+import Dialog from 'material-ui/lib/dialog';
+import ReactDOM from 'react-dom';
+
+const DLG_TYPE_WARNING = 'warning';
+const DLG_TYPE_INFO = 'info';
+
+// This function MUST be called at contructor
+export var IniEleWithInfoErrDialog = function (ele)
+{
+  ele.state.dlgType = DLG_TYPE_INFO; // info, warning
+  ele.state.dlgOpen = false;
+  ele.state.msg = "";
+}
+
+export var SetInfoErrDialog = function (ele) {
+
+  ele.showErr = function (msg) {
+     ele.setState({
+      dlgType: DLG_TYPE_WARNING,
+      dlgOpen: true,
+      msg: msg
+    })   
+  }
+
+  ele.showInfo = function (msg) {
+      ele.setState({
+      dlgType: DLG_TYPE_INFO,
+      dlgOpen: true,
+      msg: msg
+    })       
+  }
+
+  ele.closeInfoErrDialog = function (){
+    ele.setState({
+      dlgOpen: false
+    }) 
+  }
+  
+  return <Dialog title={ ele.state.dlgType == DLG_TYPE_WARNING ? 'WARNING' : 'INFO'}  open={ele.state.dlgOpen} onRequestClose={ele.closeInfoErrDialog.bind(ele)} >
+            {ele.state.msg}
+         </Dialog>
+}

--- a/imports/ui/infoErrDialog.jsx
+++ b/imports/ui/infoErrDialog.jsx
@@ -6,7 +6,7 @@ const DLG_TYPE_WARNING = 'warning';
 const DLG_TYPE_INFO = 'info';
 
 
-export var SetInfoErrDialogMethods = function (ele) {
+const SetInfoErrDialogMethods = function (ele) {
 
     ele.showErr = function (msg) {
         ele.setState({
@@ -32,7 +32,7 @@ export var SetInfoErrDialogMethods = function (ele) {
 
 }
 
-export var SetInfoErrDialog = function (ele) {
+const SetInfoErrDialog = function (ele) {
 
     var dlgType = ele.state.dlgType ? ele.state.dlgType : DLG_TYPE_INFO;
     var dlgOpen = ele.state.dlgOpen ? ele.state.dlgOpen : false;
@@ -41,3 +41,5 @@ export var SetInfoErrDialog = function (ele) {
                {ele.state.dlgmsg ? ele.state.dlgmsg : ""}
            </Dialog>
 }
+
+export {SetInfoErrDialog, SetInfoErrDialogMethods};

--- a/imports/ui/login.jsx
+++ b/imports/ui/login.jsx
@@ -35,7 +35,8 @@ class Login extends Component {
         this.state = {
             username: '',
             password: '',
-            stafflogin: false
+            stafflogin: false,
+            loginErrMsg: ""
         };
     }
     updateUsername(event) {
@@ -47,7 +48,7 @@ class Login extends Component {
     checkUser (callback) {
         Meteor.call('user.check', Meteor.user()._id, Meteor.user().username, (err) => {
             if (err) {
-                alert('User Check failed');
+                this.renderErrMsg(err);
             } else if (callback) {
                 callback();
             }
@@ -60,13 +61,19 @@ class Login extends Component {
     }
     closeStaffLogin () {
         this.setState({
-            stafflogin: false
+            stafflogin: false,
+            loginErrMsg: ""
+        });
+    }
+    renderErrMsg (err){
+        this.setState({
+            loginErrMsg: err.reason || 'Unknow login error'
         });
     }
     loginStaff () {
         Meteor.loginWithPassword(this.state.username, this.state.password, (err) => {
             if (err) {
-                alert(err);
+                this.renderErrMsg(err);
             } else {
                 this.checkUser(()=>{
                     if (Meteor.user()) {
@@ -82,7 +89,7 @@ class Login extends Component {
             password: this.state.password
         }, (err) => {
             if (err) {
-                alert(err);
+                this.renderErrMsg(err);
             } else {
                 this.loginStaff();
             }
@@ -91,7 +98,7 @@ class Login extends Component {
     loginOauth () {
         Meteor.loginWithMeteorOAuth2Server({}, (err) => {
             if (err) {
-                alert(err);
+                this.renderErrMsg(err);
             } else {
                 this.checkUser();
             }
@@ -103,7 +110,7 @@ class Login extends Component {
     loginFacebook () {
         Meteor.loginWithFacebook({}, (err) => {
             if (err) {
-                alert(err);
+                this.renderErrMsg(err);
             } else {
                 this.checkUser();
             }
@@ -131,6 +138,7 @@ class Login extends Component {
                         <TextField floatingLabelText="User Name" onChange={this.updateUsername.bind(this)} style={{width:'50%'}}/>
                         <TextField type="password" floatingLabelText="Password" onChange={this.updatePassword.bind(this)} style={{width:'50%'}}/>
                     </div>
+                    <div style={{width:'90%', marginLeft:'5%', color:"red"}}>{this.state.loginErrMsg}</div>
                     <div style={{textAlign:'center'}}>
                         <FlatButton label="GO"  primary={true} onTouchTap={this.loginStaff.bind(this)} style={{margin:'20px'}}/>
                         {

--- a/imports/ui/main.jsx
+++ b/imports/ui/main.jsx
@@ -34,7 +34,7 @@ import Avatar from 'material-ui/lib/avatar';
 import { getCurrentUserData,  isUserPassedProblem } from '../library/score_lib.js';
 import { getNumberOfUnread } from '../library/mail.js';
 
-import {SetInfoErrDialog, SetInfoErrDialogMethods} from './infoErrDialog.jsx'
+import {SetInfoErrDialog, SetInfoErrDialogMethods} from './infoErrDialog.jsx';
 
 injectTapEventPlugin(); //Workaround for Meterial-UI with React verion under 1.0
 

--- a/imports/ui/main.jsx
+++ b/imports/ui/main.jsx
@@ -34,6 +34,8 @@ import Avatar from 'material-ui/lib/avatar';
 import { getCurrentUserData,  isUserPassedProblem } from '../library/score_lib.js';
 import { getNumberOfUnread } from '../library/mail.js';
 
+import {SetInfoErrDialog, SetInfoErrDialogMethods} from './infoErrDialog.jsx'
+
 injectTapEventPlugin(); //Workaround for Meterial-UI with React verion under 1.0
 
 
@@ -68,7 +70,7 @@ class Main extends Component {
             this.navClose();
             this.goPageWrap('login');
             if (err) {
-                alert(err);
+                this.showErr(err.reason || 'Unknow logout error.');
             }
         });
     }
@@ -130,6 +132,9 @@ class Main extends Component {
             goPage(page, data);
             this.navClose();
         });
+    }
+    componentWillMount () {
+        SetInfoErrDialogMethods(this);
     }
     componentDidMount () {
         this.goPageWrap('login');
@@ -210,6 +215,7 @@ class Main extends Component {
                     {this.renderProblems()}
                 </LeftNav>
                 <div id="section"></div>
+                {SetInfoErrDialog(this)}
             </div>
         );
     }

--- a/imports/ui/problemEditor.jsx
+++ b/imports/ui/problemEditor.jsx
@@ -25,7 +25,7 @@ import { getCurrentUserData,  isUserPassedProblem } from '../library/score_lib.j
 
 import { language, docker, userData, sapporo } from '../api/db.js';
 
-import {SetInfoErrDialog, SetInfoErrDialogMethods} from './infoErrDialog.jsx'
+import {SetInfoErrDialog, SetInfoErrDialogMethods} from './infoErrDialog.jsx';
 
 const textDiv = {
     width: '96%',

--- a/imports/ui/problemEditor.jsx
+++ b/imports/ui/problemEditor.jsx
@@ -25,7 +25,7 @@ import { getCurrentUserData,  isUserPassedProblem } from '../library/score_lib.j
 
 import { language, docker, userData, sapporo } from '../api/db.js';
 
-import {SetInfoErrDialog, IniEleWithInfoErrDialog } from './infoErrDialog.jsx'
+import {SetInfoErrDialog, SetInfoErrDialogMethods} from './infoErrDialog.jsx'
 
 const textDiv = {
     width: '96%',
@@ -43,7 +43,6 @@ class ProblemEditor extends Component {
             updateLock: true,
             lastSubmitTime: null
         };
-        IniEleWithInfoErrDialog(this);
     }
     updateCode(code) {
         let tmpObj = JSON.parse(localStorage.getItem(this.props.data._id));
@@ -122,6 +121,9 @@ class ProblemEditor extends Component {
             updateLock: true
         });
     }
+    componentWillMount () {
+        SetInfoErrDialogMethods(this);
+    }
     componentDidMount () {
         this.setState({
             updateLock: false
@@ -143,17 +145,17 @@ class ProblemEditor extends Component {
         let tmpObj = JSON.parse(localStorage.getItem(this.props.data._id));
         if (!isTest) {
             if (!tmpObj.passTest) {
-                this.showErr('You must pass test before submit')
+                this.showErr('You must pass test before submit');
                 return;
             }
         }
 
         if (!tmpObj || !tmpObj.code || tmpObj.code.length === 0) {
-            this.showErr('Oops! Please at least write something.')
+            this.showErr('Oops! Please at least write something.');
             return;
         }
         else if (tmpObj.code.length > 10000) {
-            this.showErr('Your submission is rejected because your code size is too large')
+            this.showErr('Your submission is rejected because your code size is too large');
             return;
         }
 
@@ -182,7 +184,7 @@ class ProblemEditor extends Component {
                         let tmpObj = JSON.parse(localStorage.getItem(this.props.data._id));
                         tmpObj.passTest = true;
                         localStorage.setItem(this.props.data._id, JSON.stringify(tmpObj));
-                        this.showInfo('You\'ve passed testing. You can now submit your code.')
+                        this.showInfo('You\'ve passed testing. You can now submit your code.');
                     } else {
                         this.showInfo('Your submission is correct! Congrats :D');
                     }
@@ -261,7 +263,6 @@ class ProblemEditor extends Component {
             tmp.exampleOutput[langIso] = this.props.data.exampleOutput;
             Object.assign(this.props.data, tmp);
         }
-
         return (
             <div>
                 {SetInfoErrDialog(this)}
@@ -353,7 +354,6 @@ class ProblemEditor extends Component {
                         :  <LinearProgress mode="indeterminate"/>
                     }
                 </Dialog>
-
             </div>
         );
     }

--- a/imports/ui/survey.jsx
+++ b/imports/ui/survey.jsx
@@ -16,6 +16,8 @@ import FlatButton from 'material-ui/lib/flat-button';
 import AddIcon from 'material-ui/lib/svg-icons/action/note-add';
 import Divider from 'material-ui/lib/divider';
 
+import {SetInfoErrDialog, SetInfoErrDialogMethods} from './infoErrDialog.jsx';
+
 const questionSelection = [{
     description: '非常不同意',
     value: 0
@@ -191,7 +193,7 @@ class Survey extends Component {
             //console.log(this.state.survey);
             Meteor.call('survey.submit', this.state.survey, this.state.editID, (error)=>{
                 if (error) {
-                    alert(error);
+                    this.showErr("[" + error.error + "] " + error.reason);
                 }
             });
         }
@@ -204,6 +206,9 @@ class Survey extends Component {
             editID: item._id
         });
         this.toggleNewSurveyDialog();
+    }
+    componentWillMount () {
+        SetInfoErrDialogMethods(this);
     }
     renderSurveys () {
         if (this.props._surveyData) {
@@ -223,7 +228,7 @@ class Survey extends Component {
     findUserSurvey(){
         Meteor.call('survey.search', this.state.findName, (err, data)=> {
             if (err) {
-                alert(err);
+                this.showErr("[" + err.error + "] " + err.reason);
             }
             this.setState({
                 surveyFound: data
@@ -274,8 +279,7 @@ class Survey extends Component {
                             <List>
                                 {this.renderSurveys()}
                             </List>
-
-
+                            {SetInfoErrDialog(this)}
                             <Dialog title="" actions={actions} modal={false} open={this.state.newSurveyOpen} onRequestClose={this.toggleNewSurveyDialog.bind(this, true)}
                                     autoScrollBodyContent={true}>
                                 {this.renderQuestions()}
@@ -291,7 +295,6 @@ class Survey extends Component {
                         </div>
                     )
                 }
-
             </Paper>
         );
     }


### PR DESCRIPTION
Target is replace all alert and prompt in Sapporo. This is dialog
template and some implementation

infoErrDialog provides a way that ui can equip dialog
with minimal modification. Calling IniEleWithInfoErrDialog() in
contructor function to set state value dialog needs.
Setting SetInfoErrDialog() in rander part to set all show/close
functions and dialog html in code.

After setting, developers can use this.showErr() or this.showInfo()
to show message with different dialog types.

To do:
   - implement it in all jsx files.

issue: #32