### PR TITLE
FIX: UI typo and the order of updating time

### DIFF
--- a/imports/library/timeLib.js
+++ b/imports/library/timeLib.js
@@ -8,12 +8,12 @@ const generateDate = function (baseDate, year, month, day=1, hour=0, minute=0, s
         return null;
     } else {
         let time = new Date(baseDate.getTime()); //Update everything base on baseDate
-        time.setFullYear(year);
-        time.setMonth(month);
-        time.setDate(day);
-        time.setHours(hour);
-        time.setMinutes(minute);
         time.setSeconds(second);
+        time.setMinutes(minute);
+        time.setHours(hour);
+        time.setDate(day);
+        time.setMonth(month);
+        time.setFullYear(year);
         return time;
     }
 };

--- a/imports/ui/survey.jsx
+++ b/imports/ui/survey.jsx
@@ -31,7 +31,7 @@ const questionSelection = [{
     description: ['不同意', 'Disagree'],
     value: 1
 }, {
-    description: ['非常不同意', 'Strongly Agree'],
+    description: ['非常不同意', 'Strongly Disagree'],
     value: 0
 }];
 


### PR DESCRIPTION
1. FIX: Update time from second, hour, day, month, year
Avoiding the corner case if updating from year, month, day. Eg., 20181031 to 20181101

2. FIX: UI typo